### PR TITLE
Added error code from Koha.

### DIFF
--- a/app/models/reserve.rb
+++ b/app/models/reserve.rb
@@ -15,6 +15,7 @@ class Reserve
   # 'tooManyReserves',
   # 'notReservable',
   # 'cannotReserveFromOtherBranches',
+  # 'tooManyHoldsForThisRecord'
   ## Extra CGI error_codes:
   # 'borrowerNotFound',
   # 'branchCodeMissing'
@@ -30,6 +31,7 @@ class Reserve
       'tooManyReserves',
       'notReservable',
       'cannotReserveFromOtherBranches',
+      'tooManyHoldsForThisRecord',
       'borrowerNotFound',
       'branchCodeMissing',
       'itemnumberOrBiblionumberIsMissing',


### PR DESCRIPTION
- Error code 'tooManyHoldsForThisRecord' is now recognized by the
  backend and sent to frontend, underscored and capitalized,
  as 'TOO_MANY_HOLDS__FOR_THIS_RECORD'.