### PR TITLE
Fixed text in translation files for DEBARRED error.

### DIFF
--- a/frontend/app/locales/en/translations.js
+++ b/frontend/app/locales/en/translations.js
@@ -66,8 +66,8 @@ export default {
       "message": "Dina sammanlagda avgifter överstiger högsta tillåtna belopp och måste korrigeras innan nya lån kan göras."
     },
     "DEBARRED": {
-      "header": "Du har obetalda avgifter!",
-      "message": "Dina sammanlagda avgifter högsta tillåtna belopp och måste korrigeras innan nya lån kan göras."
+      "header": "Ditt konto är spärrat!",
+      "message": "Du tillåts inte låna något förrän det är upplåst."
     },
     "NO_ADDRESS": {
       "header": "Adress saknas!",

--- a/frontend/app/locales/sv/translations.js
+++ b/frontend/app/locales/sv/translations.js
@@ -66,8 +66,8 @@ export default {
       "message": "Dina sammanlagda avgifter överstiger högsta tillåtna belopp och måste korrigeras innan nya lån kan göras."
     },
     "DEBARRED": {
-      "header": "Du har obetalda avgifter!",
-      "message": "Dina sammanlagda avgifter högsta tillåtna belopp och måste korrigeras innan nya lån kan göras."
+      "header": "Ditt konto är spärrat!",
+      "message": "Du tillåts inte låna något förrän det är upplåst."
     },
     "NO_ADDRESS": {
       "header": "Adress saknas!",


### PR DESCRIPTION
Message for DEBARRED status was a duplication of the FINES message.
Now one can tell the FINES message from the DEBARRED message.