### PR TITLE
Conditional show of the note about queue size.

### DIFF
--- a/frontend/app/templates/request/order/items.hbs
+++ b/frontend/app/templates/request/order/items.hbs
@@ -2,7 +2,9 @@
   <div class="col-xs-12">
     <h3>{{request.model.biblio.title}}</h3>
     <div class="author">{{request.model.biblio.author}}</div>
+    {{#if request.model.biblio.canBeQueued}}
     <div>{{request.model.biblio.noInQueue}} i kö</div>
+    {{/if}}
   </div>
 </div>
 <hr>


### PR DESCRIPTION
This note now is shown only if patrons may queue at bilio level.
Otherwise it is hidden, since it is irrelevant.