### PR TITLE
KOHA-1856 Allow subscription reserves to be placed from Koha

### DIFF
--- a/app/controllers/api/reserves_controller.rb
+++ b/app/controllers/api/reserves_controller.rb
@@ -1,11 +1,14 @@
 class Api::ReservesController < ApplicationController
-  before_action :validate_access
+  before_action :validate_access_or_apikey
 
   def create
     # Just print order if this is subscription order
     if params[:reserve][:subscription_notes]
-      obj = Print.prepare_subscription_order(params, @current_username)
+      username = @current_username || params[:username]
+      performer_borrowernumber = params[:performer]
+      obj = Print.prepare_subscription_order(params, username)
       pdf = Print.create_pdf(obj)
+      Koha.send_statistics_from_subscription_object(obj, performer_borrowernumber: performer_borrowernumber)
       @response[:reserve] = {}
       render_json(201)
       return

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,11 +29,27 @@ class ApplicationController < ActionController::Base
   end
 
 private
+  def validate_access_or_apikey
+    if !validate_apikey && !validate_token
+      error_msg(ErrorCodes::UNAUTHORIZED, "User not valid")
+      render_json
+    end
+  end
+
   # Sets user according to token or api_key, or authenication error if fail
   def validate_access
     if !validate_token
       error_msg(ErrorCodes::UNAUTHORIZED, "User not valid")
       render_json
+    end
+  end
+
+  def validate_apikey
+    apikey = params[:api_key]
+    if apikey && apikey == APP_CONFIG['api_key']
+      return true
+    else
+      return false
     end
   end
 

--- a/app/models/koha.rb
+++ b/app/models/koha.rb
@@ -1,5 +1,6 @@
 class Koha
   def self.send_statistics_from_subscription_object(obj, performer_borrowernumber: nil)
+    stat_type = 'hold_sub'
     pickup = obj[:pickup_location_id]
     categorycode = obj[:categorycode]
     performer_borrowernumber = performer_borrowernumber
@@ -9,15 +10,15 @@ class Koha
     callno = obj[:call_number]
     location = obj[:sublocation_id]
     homebranch = obj[:sublocation_id][0..1]
-    send_statistics(pickup: pickup, categorycode: categorycode, performer_borrowernumber: performer_borrowernumber, biblionumber: biblionumber, title: title, author: author, callno: callno, location: location, homebranch: homebranch)
+    send_statistics(stat_type: stat_type, pickup: pickup, categorycode: categorycode, performer_borrowernumber: performer_borrowernumber, biblionumber: biblionumber, title: title, author: author, callno: callno, location: location, homebranch: homebranch)
   end
 
-  def self.send_statistics(pickup:, categorycode:, performer_borrowernumber: nil, biblionumber:, title:, author: nil, callno: nil, location:, homebranch:)
+  def self.send_statistics(stat_type:, pickup:, categorycode:, performer_borrowernumber: nil, biblionumber:, title:, author: nil, callno: nil, location:, homebranch:)
     stat_obj = {
       userid: APP_CONFIG['koha']['user'],
       password: APP_CONFIG['koha']['password'],
       branch: pickup,
-      type: 'hold_sub',
+      type: stat_type,
       other: homebranch,
       location: location,
       biblionumber: biblionumber,

--- a/app/models/koha.rb
+++ b/app/models/koha.rb
@@ -1,0 +1,37 @@
+class Koha
+  def self.send_statistics_from_subscription_object(obj, performer_borrowernumber: nil)
+    pickup = obj[:pickup_location_id]
+    categorycode = obj[:categorycode]
+    performer_borrowernumber = performer_borrowernumber
+    biblionumber = obj[:bibid]
+    title = obj[:title]
+    author = obj[:author]
+    callno = obj[:call_number]
+    location = obj[:sublocation_id]
+    homebranch = obj[:sublocation_id][0..1]
+    send_statistics(pickup: pickup, categorycode: categorycode, performer_borrowernumber: performer_borrowernumber, biblionumber: biblionumber, title: title, author: author, callno: callno, location: location, homebranch: homebranch)
+  end
+
+  def self.send_statistics(pickup:, categorycode:, performer_borrowernumber: nil, biblionumber:, title:, author: nil, callno: nil, location:, homebranch:)
+    stat_obj = {
+      userid: APP_CONFIG['koha']['user'],
+      password: APP_CONFIG['koha']['password'],
+      branch: pickup,
+      type: 'hold_sub',
+      other: homebranch,
+      location: location,
+      biblionumber: biblionumber,
+      title: title,
+      author: author,
+      callno: callno,
+      categorycode: categorycode,
+      borrowernumber: performer_borrowernumber
+    }
+
+    # Send to KOHA svc "ub_statistics". To prevent blocking, run it in another thread
+    Thread.new do
+      url = "#{APP_CONFIG['koha']['base_url']}/ub_statistics"
+      response = RestClient.post url, stat_obj
+    end
+  end
+end

--- a/app/models/print.rb
+++ b/app/models/print.rb
@@ -23,6 +23,7 @@ class Print
 
     pickup_location_obj = Location.find_by_id(params[:reserve][:location_id].to_i)
     obj[:pickup_location] = pickup_location_obj ? pickup_location_obj.name_sv : ''
+    obj[:pickup_location_id] = params[:reserve][:location_id].to_i
 
     biblio_obj = Biblio.find_by_id(params[:reserve][:biblio_id])
     if biblio_obj


### PR DESCRIPTION
* Accept API-key for verification of request from Koha where staff can place a subscription reserve on behalf of a patron.
* Send a request back to Koha with statistics logging whenever a subscription reserve has been made.
* A reserve made by a staff member on behalf of a patron will be logged as performed by that staff member.
* A reserve made by a patron the conventional way will be logged as performed by the app-specific admin user making the call to Koha, to prevent leaking of personal data.